### PR TITLE
Add wifiloader

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -32,6 +32,7 @@ endif
 # Wifi
 ifeq ($(BOARD_HAVE_SAMSUNG_WIFI),true)
 include $(SAM_ROOT)/macloader/Android.mk
+include $(SAM_ROOT)/wifiloader/Android.mk
 endif
 
 ifeq ($(BOARD_VENDOR),samsung)

--- a/wifiloader/Android.mk
+++ b/wifiloader/Android.mk
@@ -1,0 +1,17 @@
+ifeq ($(BOARD_HAVE_SAMSUNG_WIFI),true)
+
+LOCAL_PATH := $(call my-dir)
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := \
+    wifiloader.c
+
+LOCAL_SHARED_LIBRARIES := \
+    liblog libutils
+
+LOCAL_MODULE := wifiloader
+LOCAL_MODULE_TAGS := optional
+
+include $(BUILD_EXECUTABLE)
+
+endif

--- a/wifiloader/wifiloader.c
+++ b/wifiloader/wifiloader.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2015      Andreas Schneider <asn@cryptomilk.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG "wifiloader"
+#define LOG_NDEBUG 0
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <cutils/log.h>
+
+#define DEFERRED_INITCALLS "/proc/deferred_initcalls"
+
+int main(void)
+{
+    char buf[8] = { '\0' };
+    FILE *fp;
+    size_t r;
+
+    ALOGD("Trigger initcall of deferred modules\n");
+
+    fp = fopen(DEFERRED_INITCALLS, "r");
+    if (fp == NULL) {
+        ALOGE("Failed to open %s - error: %s\n",
+              DEFERRED_INITCALLS,
+              strerror(errno));
+        return -errno;
+    }
+
+    r = fread(buf, sizeof(buf), 1, fp);
+    fclose(fp);
+
+    ALOGV("%s=%s\n", DEFERRED_INITCALLS, buf);
+
+    return 0;
+}


### PR DESCRIPTION
This is needed on some Samsung device to load the wifi module. Before
this was solved using a bash script which does:

  cat /proc/deferred_initcalls

but the new sepolicy rules don't allow init execute bash scripts. For
this we need a new tool which does the job and we can create sepolicy
rule for it.

Change-Id: I137cfaaff74955ad431bc09d74b0c970618dc3bf
Signed-off-by: Andreas Schneider asn@cryptomilk.org
